### PR TITLE
Allow custom encoders to be used in noir.response/json

### DIFF
--- a/src/noir/response.clj
+++ b/src/noir/response.clj
@@ -1,7 +1,7 @@
 (ns noir.response
   "Simple response helpers to change the content type, redirect, or return a canned response"
   (:refer-clojure :exclude [empty])
-  (:require [cheshire.core :as json]
+  (:require [cheshire.custom :as json]
             [noir.options :as options]))
 
 (defn- ->map [c]

--- a/test/noir/test/core.clj
+++ b/test/noir/test/core.clj
@@ -54,6 +54,12 @@
         (has-content-type (content-types :json))
         (has-body "{\"noir\":\"web\"}"))))
 
+(deftest json-resp-custom-type
+  (with-noir
+    (-> (resp/json {:noir (java.awt.Color. 1 2 3)})
+        (has-content-type (content-types :json))
+        (has-body "{\"noir\":\"java.awt.Color[r=1,g=2,b=3]\"}"))))
+
 (deftest flash-lifetime
   (with-noir
     (session/flash-put! :test "noir")

--- a/test/noir/test/custom_json_encoder.clj
+++ b/test/noir/test/custom_json_encoder.clj
@@ -1,0 +1,6 @@
+(ns noir.test.custom-json-encoder
+    (:use cheshire.custom))
+
+(add-encoder java.awt.Color
+    (fn [c jsonGenerator]
+        (.writeString jsonGenerator (str c))))


### PR DESCRIPTION
Currently, noir.response/json uses cheshire.core encoders for
JSON encoding. This has limited utility for custom types, most
notably org.bson.types.ObjectId for use with MongoDB. Cheshire
supports custom encoders using cheshire.custom. Recent versions of
cheshire when using cheshire.custom (which has the same API as
cheshire.core, plus a few functions), will attempt to use core first
for faster encoding, but will fallback on any custom encoders that
have been added.

This commit changes noir.reponse/json to use cheshire.custom so that
end users can add their own encoders for types not supported by core.
